### PR TITLE
Fix min and max options

### DIFF
--- a/src/lib/bar.js
+++ b/src/lib/bar.js
@@ -11,8 +11,8 @@ export default {
 
   draw (opts) {
     var values = this.values()
-    var max = Math.max.apply(Math, opts.max ? values.concat(opts.max) : values)
-    var min = Math.min.apply(Math, opts.min ? values.concat(opts.min) : values)
+    var max = Math.max.apply(Math, opts.max == undefined ? values : values.concat(opts.max))
+    var min = Math.min.apply(Math, opts.min == undefined ? values : values.concat(opts.min))
 
     var $svg = this.prepare(opts.width, opts.height)
     var rect = $svg.getBoundingClientRect()

--- a/src/lib/line.js
+++ b/src/lib/line.js
@@ -13,8 +13,8 @@ export default {
   draw (opts) {
     var values = this.values()
     if (values.length === 1) values.push(values[0])
-    var max = Math.max.apply(Math, opts.max ? values.concat(opts.max) : values)
-    var min = Math.min.apply(Math, opts.min ? values.concat(opts.min) : values)
+    var max = Math.max.apply(Math, opts.max == undefined ? values : values.concat(opts.max))
+    var min = Math.min.apply(Math, opts.min == undefined ? values : values.concat(opts.min))
 
     var $svg = this.prepare(opts.width, opts.height)
     var rect = $svg.getBoundingClientRect()


### PR DESCRIPTION
Fix both the bar and line charts when the `min` or `max` option is set to `0`.
